### PR TITLE
Exposes the Handlebars.js precompile method

### DIFF
--- a/lib/handlebars/context.rb
+++ b/lib/handlebars/context.rb
@@ -27,6 +27,10 @@ module Handlebars
       ::Handlebars::Template.new(self, handlebars.compile(*args))
     end
 
+    def precompile(*args)
+      handlebars.precompile(*args)
+    end
+
     def register_helper(name, &fn)
       handlebars.registerHelper(name, fn)
     end


### PR DESCRIPTION
You can pretty easily get to the Handebars.js precompile method, but it would be very convenient to expose the method directly through the Handlebars Ruby bindings.
