### PR TITLE
Update handlebars.gemspec for fixing rubyracer version for libv8 installation bug on OSX Mavericks

### DIFF
--- a/handlebars.gemspec
+++ b/handlebars.gemspec
@@ -20,10 +20,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   Dir.chdir("vendor/handlebars") do
     s.files += `git ls-files`.split("\n").map {|f| "vendor/handlebars/#{f}"}
-    s.files += ['vendor/handlebars/lib/handlebars/compiler/parser.js']
   end
 
-  s.add_dependency "therubyracer", "~> 0.11.1"
+  s.add_dependency "therubyracer", "~> 0.12.0"
   s.add_dependency "commonjs", "~> 0.2.3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 2.0"


### PR DESCRIPTION
Fixes this issue [https://github.com/cowboyd/therubyracer/issues/269]
