### PR TITLE
init context with addition js

### DIFF
--- a/lib/handlebars/context.rb
+++ b/lib/handlebars/context.rb
@@ -3,10 +3,10 @@ require 'v8'
 
 module Handlebars
   class Context
-    def initialize
+    def initialize(args = {})
       @js = V8::Context.new
       @js.load(Handlebars::Source.bundled_path)
-
+      @js.load(args[:with]) if args.key?(:with)
       @partials = handlebars.partials = Handlebars::Partials.new
     end
 


### PR DESCRIPTION
Initialize new context with optional JavaScript addition, shared for both client and server, such as helpers.

hbs = Handlebars::Context.new with: File.expand_path('js/helpers.js')