### PR TITLE
Loads helpers written in pure javascript files

### DIFF
--- a/lib/handlebars/context.rb
+++ b/lib/handlebars/context.rb
@@ -14,6 +14,14 @@ module Handlebars
       ::Handlebars::Template.new(self, handlebars.compile(*args))
     end
 
+    def load_helpers(helpers_pattern)
+      Dir[helpers_pattern].each{ |path| load_helper(path) }
+    end
+
+    def load_helper(path)
+      @js.load(path)
+    end
+
     def precompile(*args)
       handlebars.precompile(*args)
     end

--- a/spec/handlebars_spec.rb
+++ b/spec/handlebars_spec.rb
@@ -24,6 +24,17 @@ describe(Handlebars::Context) do
     end
   end
 
+  describe "loading Helpers" do
+    before do
+      subject.load_helper('spec/sample_helper.js')
+    end
+
+    it "can call helpers defined in a javascript file" do
+      t = compile('{{#nthTimes 2}}yep {{/nthTimes}}hurrah!')
+      t.call.should eql 'yep yep hurrah!'
+    end
+  end
+
   describe "registering Helpers" do
     before do
       subject.register_helper('alsowith') do |this, context, block|

--- a/spec/sample_helper.js
+++ b/spec/sample_helper.js
@@ -1,0 +1,9 @@
+Handlebars.registerHelper("nthTimes", function(n, options){
+  var buffer = "";
+
+  for(var i = 0; i < n; i++) {
+    buffer += options.fn();
+  }
+
+  return buffer;
+});


### PR DESCRIPTION
This pull request allow us to load pure javascript files that contains helpers and other utility functions.
The motivation behind it, is to reuse already created helpers, that works on browser and could be used in server.