### PR TITLE
update SafeString outside template evaluation

### DIFF
--- a/lib/handlebars/safe_string.rb
+++ b/lib/handlebars/safe_string.rb
@@ -4,7 +4,8 @@ module Handlebars
       if context = Context.current
         context.handlebars['SafeString'].new(string)
       else
-        fail "Cannot instantiate Handlebars.SafeString outside a running template Evaluation"
+        warn "Cannot instantiate Handlebars.SafeString outside a running template Evaluation"
+        string
       end
     end
   end


### PR DESCRIPTION
When outside template evaluation changes SafeString to use  `warn` instead of `fail` and returns the string. 

I'm trying to re-use the data for rendering templates on the server and for sending to a view as a json object. This allows me to:

```ruby
@hash_with_html_safe_things = data.each_with_object({}) do |(key, value), result|  
  if value.class.to_s == 'Proc'
      result[k] = v.call.html_safe
  else
    result[k] = v
  end
end
```