### PR TITLE
Handlebars v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ pkg/*
 *.gem
 .bundle
 Gemfile.lock
+.ruby-gemset
+.ruby-version

--- a/README.mdown
+++ b/README.mdown
@@ -106,6 +106,14 @@ Missing partials can also be returned as a function:
     t.call #=> 1 miss(es) when trying to look up a partial
     t.call #=> 2 miss(es) when tyring to look up a partial
 
+### Security
+
+In general, you should not trust user-provided templates: a template can call any method
+(with no arguments) or access any property on any object in the `Handlebars::Context`.
+
+If you'd like to render user-provided templates, you'd want to make sure you do so in a
+sanitized Context, e.g. no filesystem access, read-only or no database access, etc.
+
 ## Test
 
     rspec spec/

--- a/handlebars.gemspec
+++ b/handlebars.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files lib README.mdown`.split("\n")
 
-  s.add_dependency "therubyracer", "~> 0.12.0"
-  s.add_dependency "handlebars-source", "~> 2.0.0"
+  s.add_dependency "therubyracer", "~> 0.12.1"
+  s.add_dependency "handlebars-source", "~> 3.0.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 2.0"
 end

--- a/lib/handlebars/context.rb
+++ b/lib/handlebars/context.rb
@@ -5,6 +5,7 @@ module Handlebars
   class Context
     def initialize
       @js = V8::Context.new
+      @js['global'] = {} # there may be a more appropriate object to be used here @MHW
       @js.load(Handlebars::Source.bundled_path)
 
       @partials = handlebars.partials = Handlebars::Partials.new

--- a/lib/handlebars/version.rb
+++ b/lib/handlebars/version.rb
@@ -1,3 +1,3 @@
 module Handlebars
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
Upgrades the underlying handlebars library to v3.x and adds a short note to the readme.