### PR TITLE
README: Remove Gemnasium badge

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -2,8 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/handlebars.png)](http://badge.fury.io/rb/handlebars)
 [![Build Status](https://travis-ci.org/cowboyd/handlebars.rb.png?branch=master)](https://travis-ci.org/cowboyd/handlebars.rb)
-[![Dependency Status](https://gemnasium.com/cowboyd/handlebars.rb.png)](https://gemnasium.com/cowboyd/handlebars.rb)
-
 
 This uses [therubyracer][1] to bind to the _actual_ JavaScript implementation of
 [Handlebars.js][2] so that you can use it from ruby.


### PR DESCRIPTION
This PR removes a badge from a defunct service.